### PR TITLE
NRotMEncounterRouting "test" method

### DIFF
--- a/EncounterRoutingNRotM/main.py
+++ b/EncounterRoutingNRotM/main.py
@@ -163,7 +163,9 @@ class CloudGame(LocalGame):
             "fields": "sheets.data.rowData.values.dataValidation,sheets.data.rowData.values.userEnteredValue.stringValue",
         }
 
-        self.sheet_data = self.api.main(api_call_params, "ss", self.run_config["output_json_path"])
+        self.sheet_data = self.api.main(
+            api_call_params, "ss", self.run_config["output_json_path"]
+        )
 
         # init pokeapi calls
         self.pokeapi = pokeapi.PokeapiAccess()
@@ -178,7 +180,12 @@ class CloudGame(LocalGame):
             "range": f"Team & Encounters!N5:N{5 + n_routes}",
         }
         self.encounter_status_response = self.api.main(api_call_params, "ss_values")
-        self.encounter_status = self.encounter_status_response.get("values", []) + [[] for _ in range(n_routes-len(self.encounter_status_response.get("values", [])))]
+        self.encounter_status = self.encounter_status_response.get("values", []) + [
+            []
+            for _ in range(
+                n_routes - len(self.encounter_status_response.get("values", []))
+            )
+        ]
 
         # initialize encounter info
         self.encounter_data, self.encounters, self.route_order, self.failed_routes = (
@@ -505,7 +512,9 @@ class NRotMEncounterRouting:
                 and sum(row[self.GameData.honey_mons]) == row.sum()
                 and index not in group_data.routes
             ]
-            flag_group_data = GroupData(remaining_honey_routes, self.GameData.honey_mons)
+            flag_group_data = GroupData(
+                remaining_honey_routes, self.GameData.honey_mons
+            )
             flag_group_data.assign_me = {
                 route: " or ".join(flag_group_data.encounters)
                 for route in flag_group_data.routes

--- a/EncounterRoutingNRotM/main.py
+++ b/EncounterRoutingNRotM/main.py
@@ -292,6 +292,8 @@ class NRotMEncounterRouting:
 
         if self.args.route:
             self.route()
+        if self.args.test:
+            self.test()
 
     def import_encounters_json(self, encounters_path):
         with open(encounters_path, "r") as f:
@@ -351,6 +353,40 @@ class NRotMEncounterRouting:
             action="store_true",
         )
         return parser
+
+    def test(self):
+        working_df = self.encounter_tables[-1].copy()
+        route, encounter = input(
+            "What pair would you like to test? \n\tformat as (route):(encounter)\n> "
+        ).split(":")
+
+        # validate encounter, route, and pair
+        valid_encounter = re.search(
+            r"(?:(?<=\n)|.*){}.*(?=\n|$)".format(encounter),
+            "\n".join(working_df.columns),
+            flags=re.I | re.M,
+        )
+
+        if not valid_encounter:
+            print("Type a valid encounter!")
+            self.test()
+
+        valid_route = route in working_df.index
+        if not valid_route:
+            print("Type a valid route!")
+            self.test()
+
+        valid_pair = working_df.loc[route, encounter]
+        if False not in [valid_encounter, valid_route, valid_pair]:
+            # test the pair
+
+            group_data = GroupData(
+                routes=[route],
+                encounters=[encounter],
+                assign_me={route: encounter},
+            )
+
+            working_df = self.update(group_data, working_df)
 
     def route(self):
         methods = {self.assign_one_to_one: True, self.check_duplicates: True}

--- a/EncounterRoutingNRotM/main.py
+++ b/EncounterRoutingNRotM/main.py
@@ -364,7 +364,7 @@ class NRotMEncounterRouting:
 
         # ask user about unique encounters before finishing?
         self.print_progress(
-            pd.DataFrame.from_dict({"Encounter": self.assigned_encounters}), "*=="
+            pd.DataFrame.from_dict({"Encounter": self.assigned_encounters}), "*=*=*"
         )
         self.export_table()
 


### PR DESCRIPTION
- use the command line argument `-t` and provide a route/pokemon pair to test as an encounter
- The program will output what encounters are lost globally 

Fix:
- google sheet is still read appropriately even if the sheet is blank

Closes #34 #52 